### PR TITLE
Design change event format and serialization. Implement change publishing on local operations and add remote change application logic.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +166,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytes"
@@ -412,6 +433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +498,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "json5"
@@ -534,18 +571,24 @@ name = "merkle_kv"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
+ "bincode",
  "clap",
  "config",
  "env_logger",
  "log",
  "mockall",
+ "once_cell",
+ "rand",
  "rumqttc",
  "serde",
+ "serde_cbor",
  "serde_json",
  "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -734,6 +777,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +834,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -841,7 +923,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bitflags 1.3.2",
  "serde",
 ]
@@ -950,6 +1032,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1088,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1255,6 +1353,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1382,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1462,6 +1629,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ description = "A distributed key-value store with Merkle tree for efficient sync
 tokio = { version = "1.35.1", features = ["full"] }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"
+serde_cbor = "0.11"
+bincode = "1.3"
 log = "0.4.20"
 env_logger = "0.10.1"
 clap = { version = "4.4.18", features = ["derive"] }
@@ -17,7 +19,11 @@ thiserror = "1.0.56"
 config = "0.13.4"
 rumqttc = "0.24.0"
 sha2 = "0.10.8"
+uuid = { version = "1", features = ["v4"] }
+base64 = "0.22"
+once_cell = "1.19"
 
 [dev-dependencies]
 tempfile = "3.9.0"
 mockall = "0.12.1"
+rand = "0.8"

--- a/src/change_event.rs
+++ b/src/change_event.rs
@@ -337,7 +337,7 @@ fn same_timestamp_tie_break_by_op_id() {
     let mut applier = LocalApplier::new();
     let mut ev1 = sample_event(OpKind::Set, "tie", Some("A"), 500);
     let mut ev2 = sample_event(OpKind::Set, "tie", Some("B"), 500);
-    // định nghĩa: chọn sự kiện có op_id lexicographically larger
+    // Definition: choose the event with the lexicographically larger op_id
     let winner_is_ev2 = ev2.op_id > ev1.op_id;
     applier.apply(&ev1);
     applier.apply(&ev2);

--- a/src/change_event.rs
+++ b/src/change_event.rs
@@ -416,7 +416,7 @@ fn self_origin_event_ignored() {
 fn ttl_is_advisory_only() {
     let mut a = LocalApplier::new();
     let mut ev = sample_event(OpKind::Set, "ttl", Some("x"), 50);
-    // Thêm TTL ≠ auto-expire (theo prototype)
+    // Adding TTL does not mean auto-expire (according to the prototype)
     ev.ttl = Some(1);
     a.apply(&ev);
     assert_eq!(a.store.get("ttl").cloned(), Some("x".into()));

--- a/src/change_event.rs
+++ b/src/change_event.rs
@@ -1,0 +1,429 @@
+//! # Change Events: Format, Serialization, and Teaching Notes
+//!
+//! This module defines the canonical “change event” used to propagate state
+//! between nodes in an eventually consistent system. Each local write produces
+//! a `ChangeEvent` which can be serialized (JSON, CBOR, or Bincode) and
+//! distributed via a transport (MQTT in this project). Remote nodes deserialize
+//! and apply these events idempotently, resolving conflicts via Last-Write-Wins
+//! (LWW) using a timestamp. The commentary is intentionally scholarly to help
+//! students understand the “why”, not just the “what”.
+//!
+//! Key distributed systems concepts illustrated here:
+//! - Event propagation and at-least-once delivery (QoS 1)
+//! - Idempotency using an operation identifier (UUID v4)
+//! - LWW conflict resolution using a physical or logical timestamp
+//! - Optional Merkle hash pointers to support anti-entropy protocols
+//!
+//! The event’s `val` carries the resulting value after the operation (for SET,
+//! INCR/DECR, APPEND/PREPEND). This choice makes idempotent application simple
+//! and makes LWW straightforward: the winner simply becomes “the value”.
+
+use serde::{Deserialize, Serialize};
+
+/// The operation kind carried by a change event.
+///
+/// We use compact lowercase tags in serialized form to minimize payload size.
+/// For teaching: these operations are the minimal set needed to illustrate
+/// common writes in a KV store while demonstrating that “SET-like” writes can
+/// encode their result so that LWW can simply overwrite state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OpKind {
+    /// Store or overwrite a value
+    Set,
+    /// Delete a key
+    Del,
+    /// Numeric increment; event value contains the resulting number as bytes
+    Incr,
+    /// Numeric decrement; event value contains the resulting number as bytes
+    Decr,
+    /// String append; event value contains the resulting string as bytes
+    Append,
+    /// String prepend; event value contains the resulting string as bytes
+    Prepend,
+}
+
+/// Canonical change-event structure used to replicate writes.
+///
+/// - `v` (schema version): Enables evolution of the on-wire format.
+/// - `op`: What kind of mutation this is (set/del/incr/decr/append/prepend).
+/// - `key`: The logical key being mutated.
+/// - `val`: The resulting value as raw bytes (UTF-8 for string values, ASCII
+///          digits for numeric results); `None` for deletions.
+/// - `ts`: A timestamp for conflict resolution. We allow Unix nanoseconds or a
+///         logical clock; the comparison is the only semantic the system needs.
+/// - `src`: The originating node identifier, used for loop prevention.
+/// - `op_id`: A 128-bit identifier (UUID v4) for idempotency/deduplication.
+/// - `prev`: Optional 32-byte Merkle root (or leaf) hash to assist anti-entropy.
+/// - `ttl`: Optional TTL-in-seconds hint (not enforced by the in-memory engine).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeEvent {
+    /// Schema version (allows additive, backward-compatible upgrades)
+    pub v: u16,
+    /// Operation kind
+    pub op: OpKind,
+    /// Key under mutation
+    pub key: String,
+    /// Resulting value after mutation; None for deletions
+    pub val: Option<Vec<u8>>, // bytes to be agnostic to codec and content
+    /// Timestamp for LWW resolution (unix_nanos or logical clock)
+    pub ts: u64,
+    /// Originating node id
+    pub src: String,
+    /// Operation id for idempotency (UUID v4 bytes)
+    pub op_id: [u8; 16],
+    /// Optional Merkle hash (32 bytes). Useful for anti-entropy proofs.
+    pub prev: Option<[u8; 32]>,
+    /// Optional TTL in seconds (advisory in this prototype)
+    pub ttl: Option<u64>,
+}
+
+impl ChangeEvent {
+    /// Construct a new change event with the provided fields.
+    ///
+    /// We generate an operation id (UUID v4) to make this event idempotent
+    /// under at-least-once delivery. Timestamps should be monotonic within a
+    /// node for LWW to be meaningful. Using `unix_nanos` is sufficient for a
+    /// prototype; Lamport clocks would improve causality ordering across nodes.
+    pub fn new(
+        v: u16,
+        op: OpKind,
+        key: impl Into<String>,
+        val: Option<Vec<u8>>,
+        ts: u64,
+        src: impl Into<String>,
+        prev: Option<[u8; 32]>,
+        ttl: Option<u64>,
+    ) -> Self {
+        let op_id = uuid::Uuid::new_v4().into_bytes();
+        Self {
+            v,
+            op,
+            key: key.into(),
+            val,
+            ts,
+            src: src.into(),
+            op_id,
+            prev,
+            ttl,
+        }
+    }
+
+    /// Helper: Build an event whose value is a UTF-8 string.
+    pub fn with_str_value(
+        v: u16,
+        op: OpKind,
+        key: impl Into<String>,
+        value: Option<&str>,
+        ts: u64,
+        src: impl Into<String>,
+        prev: Option<[u8; 32]>,
+        ttl: Option<u64>,
+    ) -> Self {
+        let val = value.map(|s| s.as_bytes().to_vec());
+        Self::new(v, op, key, val, ts, src, prev, ttl)
+    }
+
+    /// Serialize the event to JSON. Human-readable and easy to debug.
+    pub fn to_json(&self) -> serde_json::Result<Vec<u8>> {
+        serde_json::to_vec(self)
+    }
+
+    /// Serialize the event to CBOR. Compact, self-describing binary format.
+    pub fn to_cbor(&self) -> serde_cbor::Result<Vec<u8>> {
+        serde_cbor::to_vec(self)
+    }
+
+    /// Serialize the event to Bincode. Very compact, not self-describing.
+    pub fn to_bincode(&self) -> bincode::Result<Vec<u8>> {
+        bincode::serialize(self)
+    }
+
+    /// Deserialize from JSON bytes.
+    pub fn from_json(bytes: &[u8]) -> serde_json::Result<Self> {
+        serde_json::from_slice(bytes)
+    }
+
+    /// Deserialize from CBOR bytes.
+    pub fn from_cbor(bytes: &[u8]) -> serde_cbor::Result<Self> {
+        serde_cbor::from_slice(bytes)
+    }
+
+    /// Deserialize from Bincode bytes.
+    pub fn from_bincode(bytes: &[u8]) -> bincode::Result<Self> {
+        bincode::deserialize(bytes)
+    }
+
+    /// Attempt to decode using CBOR, then Bincode, then JSON.
+    ///
+    /// This is useful for subscribers that accept multiple codecs without
+    /// negotiating content-types on the transport.
+    pub fn decode_any(bytes: &[u8]) -> Result<Self, String> {
+        if let Ok(e) = Self::from_cbor(bytes) {
+            return Ok(e);
+        }
+        if let Ok(e) = Self::from_bincode(bytes) {
+            return Ok(e);
+        }
+        if let Ok(e) = Self::from_json(bytes) {
+            return Ok(e);
+        }
+        Err("Failed to decode ChangeEvent with CBOR, Bincode, or JSON".into())
+    }
+}
+
+/// Preferred encoding for on-wire messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeCodec {
+    Json,
+    Cbor,
+    Bincode,
+}
+
+impl ChangeCodec {
+    /// Serialize according to the selected codec.
+    pub fn encode(self, ev: &ChangeEvent) -> Result<Vec<u8>, String> {
+        match self {
+            ChangeCodec::Json => ev.to_json().map_err(|e| e.to_string()),
+            ChangeCodec::Cbor => ev.to_cbor().map_err(|e| e.to_string()),
+            ChangeCodec::Bincode => ev.to_bincode().map_err(|e| e.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+
+    /// A minimal local applier used for unit tests without MQTT.
+    ///
+    /// Pedagogical note: this mirrors the LWW/idempotency logic used by the
+    /// networked subscriber, but runs on a plain HashMap to keep tests simple.
+    struct LocalApplier {
+        seen: HashSet<[u8; 16]>,
+        last_ts: HashMap<String, u64>,
+        store: HashMap<String, String>,
+    }
+
+    impl LocalApplier {
+        fn new() -> Self {
+            Self { seen: HashSet::new(), last_ts: HashMap::new(), store: HashMap::new() }
+        }
+
+        /// Apply a change using idempotency and LWW semantics.
+        fn apply(&mut self, ev: &ChangeEvent) {
+            if self.seen.contains(&ev.op_id) {
+                return; // idempotent: ignore duplicates
+            }
+            let ts_entry = self.last_ts.get(&ev.key).cloned().unwrap_or(0);
+            if ev.ts < ts_entry {
+                return; // LWW: ignore older events
+            }
+            match ev.op {
+                OpKind::Del => {
+                    self.store.remove(&ev.key);
+                }
+                _ => {
+                    if let Some(bytes) = &ev.val {
+                        let s = String::from_utf8(bytes.clone()).unwrap_or_else(|_| base64::encode(bytes));
+                        self.store.insert(ev.key.clone(), s);
+                    }
+                }
+            }
+            self.last_ts.insert(ev.key.clone(), ev.ts);
+            self.seen.insert(ev.op_id);
+        }
+    }
+
+    fn sample_event(op: OpKind, key: &str, val: Option<&str>, ts: u64) -> ChangeEvent {
+        ChangeEvent::with_str_value(1, op, key.to_string(), val, ts, "nodeA", None, None)
+    }
+
+    #[test]
+    fn json_cbor_bincode_roundtrip() {
+        let ev = sample_event(OpKind::Set, "k", Some("v"), 123);
+        let j = ev.to_json().unwrap();
+        let c = ev.to_cbor().unwrap();
+        let b = ev.to_bincode().unwrap();
+        assert_eq!(ChangeEvent::from_json(&j).unwrap(), ev);
+        assert_eq!(ChangeEvent::from_cbor(&c).unwrap(), ev);
+        assert_eq!(ChangeEvent::from_bincode(&b).unwrap(), ev);
+        assert_eq!(ChangeEvent::decode_any(&c).unwrap(), ev);
+    }
+
+    #[test]
+    fn idempotency_duplicate_event() {
+        let mut applier = LocalApplier::new();
+        let mut ev = sample_event(OpKind::Set, "x", Some("1"), 10);
+        // Ensure same op id for duplicate
+        let op_id = ev.op_id;
+        applier.apply(&ev);
+        applier.apply(&ev); // duplicate
+        assert_eq!(applier.store.get("x").cloned(), Some("1".into()));
+        // Build a new identical event with the same op_id
+        let mut ev2 = sample_event(OpKind::Set, "x", Some("1"), 10);
+        ev2.op_id = op_id;
+        applier.apply(&ev2);
+        assert_eq!(applier.store.get("x").cloned(), Some("1".into()));
+    }
+
+    #[test]
+    fn lww_out_of_order_delivery() {
+        let mut applier = LocalApplier::new();
+        // Newer event arrives first
+        let ev_new = sample_event(OpKind::Set, "c", Some("new"), 200);
+        let mut ev_old = sample_event(OpKind::Set, "c", Some("old"), 100);
+        applier.apply(&ev_new);
+        applier.apply(&ev_old); // should be ignored by LWW
+        assert_eq!(applier.store.get("c").cloned(), Some("new".into()));
+        // Now deliver in reverse order on a fresh key
+        let mut applier2 = LocalApplier::new();
+        let ev_old2 = sample_event(OpKind::Set, "d", Some("old"), 100);
+        let ev_new2 = sample_event(OpKind::Set, "d", Some("new"), 200);
+        applier2.apply(&ev_old2);
+        applier2.apply(&ev_new2);
+        assert_eq!(applier2.store.get("d").cloned(), Some("new".into()));
+    }
+    fn mixed_codec_interop() {
+    let ev = sample_event(OpKind::Set, "k", Some("v"), 1_000);
+    let j = ev.to_json().unwrap();
+    let c = ev.to_cbor().unwrap();
+    let b = ev.to_bincode().unwrap();
+
+    assert_eq!(ChangeEvent::decode_any(&j).unwrap(), ev);
+    assert_eq!(ChangeEvent::decode_any(&c).unwrap(), ev);
+    assert_eq!(ChangeEvent::decode_any(&b).unwrap(), ev);
+}
+#[test]
+fn corrupted_payload_rejected() {
+    let garbage = b"\x00\x01\x02not-a-valid-payload";
+    let err = ChangeEvent::decode_any(garbage).unwrap_err();
+    assert!(err.to_lowercase().contains("failed"));
+}
+#[test]
+fn non_utf8_value_safe_handling() {
+    let mut applier = LocalApplier::new();
+    let mut bytes = vec![0, 159, 146, 150]; // invalid UTF-8
+    let ev = ChangeEvent::new(1, OpKind::Set, "bin", Some(bytes.clone()), 5, "A", None, None);
+    applier.apply(&ev);
+    // LocalApplier stringify non-UTF8 via base64 fallback
+    let got = applier.store.get("bin").unwrap();
+    assert_eq!(got, &base64::encode(&bytes));
+}
+#[test]
+fn idempotency_burst_duplicates() {
+    let mut applier = LocalApplier::new();
+    let mut ev = sample_event(OpKind::Set, "dup", Some("1"), 10);
+    let op_id = ev.op_id;
+    for _ in 0..10 { applier.apply(&ev); }
+    assert_eq!(applier.store.get("dup").cloned(), Some("1".into()));
+
+    // Even a freshly built event with the same op_id is ignored
+    let mut ev2 = sample_event(OpKind::Set, "dup", Some("1"), 10);
+    ev2.op_id = op_id;
+    applier.apply(&ev2);
+    assert_eq!(applier.store.get("dup").cloned(), Some("1".into()));
+}
+#[test]
+fn lww_clock_skew_no_overwrite() {
+    let mut a = LocalApplier::new();
+    a.apply(&sample_event(OpKind::Set, "t", Some("newer"), 2000));
+    a.apply(&sample_event(OpKind::Set, "t", Some("older"), 1000)); // late & older
+    assert_eq!(a.store.get("t").cloned(), Some("newer".into()));
+}
+#[test]
+fn same_timestamp_tie_break_by_op_id() {
+    let mut applier = LocalApplier::new();
+    let mut ev1 = sample_event(OpKind::Set, "tie", Some("A"), 500);
+    let mut ev2 = sample_event(OpKind::Set, "tie", Some("B"), 500);
+    // định nghĩa: chọn sự kiện có op_id lexicographically larger
+    let winner_is_ev2 = ev2.op_id > ev1.op_id;
+    applier.apply(&ev1);
+    applier.apply(&ev2);
+    let expect = if winner_is_ev2 {"B"} else {"A"};
+    assert_eq!(applier.store.get("tie").cloned(), Some(expect.into()));
+}
+#[test]
+fn per_key_ts_isolation() {
+    let mut a = LocalApplier::new();
+    // key x có ts thấp hơn nhưng không ảnh hưởng key y
+    a.apply(&sample_event(OpKind::Set, "x", Some("1"), 5));
+    a.apply(&sample_event(OpKind::Set, "y", Some("9"), 100));
+    a.apply(&sample_event(OpKind::Set, "x", Some("2"), 6)); // hợp lệ
+    // Nếu áp sai, ts của y có thể vô tình chặn x
+    assert_eq!(a.store.get("x").cloned(), Some("2".into()));
+    assert_eq!(a.store.get("y").cloned(), Some("9".into()));
+}
+#[test]
+fn delete_lww_behavior() {
+    let mut a = LocalApplier::new();
+    a.apply(&sample_event(OpKind::Set, "z", Some("keep"), 10));
+    a.apply(&sample_event(OpKind::Del, "z", None, 11));
+    assert!(a.store.get("z").is_none());
+}
+#[test]
+fn missing_value_for_non_del_is_ignored() {
+    let mut a = LocalApplier::new();
+    let ev = ChangeEvent::new(1, OpKind::Set, "m", None, 5, "node", None, None);
+    a.apply(&ev);
+    assert!(a.store.get("m").is_none());
+}
+#[test]
+fn large_payload_roundtrip() {
+    let big = vec![b'x'; 256 * 1024]; // 256KB
+    let ev = ChangeEvent::new(1, OpKind::Set, "big", Some(big.clone()), 42, "node", None, None);
+    let b = ev.to_bincode().unwrap();
+    let de = ChangeEvent::from_bincode(&b).unwrap();
+    assert_eq!(de.val.unwrap(), big);
+}
+#[test]
+fn append_prepend_store_result_value() {
+    let mut a = LocalApplier::new();
+    // Giả định server đã tính sẵn kết quả và nhét vào val
+    a.apply(&sample_event(OpKind::Set, "s", Some("core"), 1));
+    a.apply(&sample_event(OpKind::Append, "s", Some("core+tail"), 2));
+    assert_eq!(a.store.get("s").cloned(), Some("core+tail".into()));
+    a.apply(&sample_event(OpKind::Prepend, "s", Some("head+core+tail"), 3));
+    assert_eq!(a.store.get("s").cloned(), Some("head+core+tail".into()));
+}
+#[test]
+fn incr_decr_ascii_numeric_result() {
+    let mut a = LocalApplier::new();
+    a.apply(&sample_event(OpKind::Set, "n", Some("10"), 1));
+    a.apply(&sample_event(OpKind::Incr, "n", Some("11"), 2));
+    a.apply(&sample_event(OpKind::Decr, "n", Some("9"), 3));
+    assert_eq!(a.store.get("n").cloned(), Some("9".into()));
+}
+#[test]
+fn replay_without_dedupe_still_lww_correct() {
+    let mut a = LocalApplier::new();
+    let ev_new = sample_event(OpKind::Set, "r", Some("new"), 200);
+    let ev_old = sample_event(OpKind::Set, "r", Some("old"), 100);
+    // phiên 1
+    a.apply(&ev_new);
+    // “restart” -> seen/last_ts trống
+    let mut b = LocalApplier::new();
+    b.apply(&ev_old);  // cũ → set
+    b.apply(&ev_new);  // mới → overwrite
+    assert_eq!(b.store.get("r").cloned(), Some("new".into()));
+}
+#[test]
+fn self_origin_event_ignored() {
+    // LocalApplier không có src check, nhưng Subscriber thật phải có.
+    // Ở đây mô phỏng bằng cách xác nhận business rule:
+    let ev = ChangeEvent::with_str_value(1, OpKind::Set, "self", Some("v"), 10, "nodeA", None, None);
+    assert_eq!(ev.src, "nodeA");
+    // Gợi ý: test này nên nằm trong test của Subscriber thực tế, nơi có node_id local.
+}
+#[test]
+fn ttl_is_advisory_only() {
+    let mut a = LocalApplier::new();
+    let mut ev = sample_event(OpKind::Set, "ttl", Some("x"), 50);
+    // Thêm TTL ≠ auto-expire (theo prototype)
+    ev.ttl = Some(1);
+    a.apply(&ev);
+    assert_eq!(a.store.get("ttl").cloned(), Some("x".into()));
+}
+
+}

--- a/src/change_event.rs
+++ b/src/change_event.rs
@@ -406,8 +406,8 @@ fn replay_without_dedupe_still_lww_correct() {
 }
 #[test]
 fn self_origin_event_ignored() {
-    // LocalApplier không có src check, nhưng Subscriber thật phải có.
-    // Ở đây mô phỏng bằng cách xác nhận business rule:
+    // LocalApplier does not check src, but a real Subscriber must.
+    // Here we simulate by verifying the business rule:
     let ev = ChangeEvent::with_str_value(1, OpKind::Set, "self", Some("v"), 10, "nodeA", None, None);
     assert_eq!(ev.src, "nodeA");
     // Gợi ý: test này nên nằm trong test của Subscriber thực tế, nơi có node_id local.

--- a/src/change_event.rs
+++ b/src/change_event.rs
@@ -376,7 +376,7 @@ fn large_payload_roundtrip() {
 #[test]
 fn append_prepend_store_result_value() {
     let mut a = LocalApplier::new();
-    // Giả định server đã tính sẵn kết quả và nhét vào val
+    // Assume the server has already computed the result and put it into val
     a.apply(&sample_event(OpKind::Set, "s", Some("core"), 1));
     a.apply(&sample_event(OpKind::Append, "s", Some("core+tail"), 2));
     assert_eq!(a.store.get("s").cloned(), Some("core+tail".into()));

--- a/src/change_event.rs
+++ b/src/change_event.rs
@@ -347,11 +347,7 @@ fn same_timestamp_tie_break_by_op_id() {
 #[test]
 fn per_key_ts_isolation() {
     let mut a = LocalApplier::new();
-    // key x có ts thấp hơn nhưng không ảnh hưởng key y
-    a.apply(&sample_event(OpKind::Set, "x", Some("1"), 5));
-    a.apply(&sample_event(OpKind::Set, "y", Some("9"), 100));
-    a.apply(&sample_event(OpKind::Set, "x", Some("2"), 6)); // hợp lệ
-    // Nếu áp sai, ts của y có thể vô tình chặn x
+    // If applied incorrectly, the timestamp of y could accidentally block x
     assert_eq!(a.store.get("x").cloned(), Some("2".into()));
     assert_eq!(a.store.get("y").cloned(), Some("9".into()));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod replication; // MQTT-based replication (stub)
 mod server; // TCP server for client connections
 mod store; // Storage engine and Merkle tree
 mod sync; // Anti-entropy synchronization (stub)
+mod change_event; // Change event schema & codecs
 
 // Import storage engines
 use crate::store::{KVEngineStoreTrait, KvEngine, RwLockEngine};


### PR DESCRIPTION
This pull request introduces a major refactor of the replication system, moving from a simple JSON-based message format to a more robust, extensible change event schema with pluggable codecs. The new design improves idempotency, supports more operation types, and separates transport from application logic using channels. It also lays the groundwork for more advanced replication features and better integration with the storage engine.

**Replication protocol and event handling:**

* Replaces the old `ReplicationMessage` struct and JSON serialization with a new `ChangeEvent` schema and pluggable codecs (CBOR by default), supporting a wider range of operations and improving extensibility. (`src/replication.rs`, `Cargo.toml`, `src/main.rs`) [[1]](diffhunk://#diff-a2e88f1e108c7f80dc6918e1b0aa875cdede712521e4adb4e578f4608e19aa99L41-R56) [[2]](diffhunk://#diff-a2e88f1e108c7f80dc6918e1b0aa875cdede712521e4adb4e578f4608e19aa99L169-R162) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R12-R13) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR36)
* Implements idempotency, loop prevention, and last-write-wins (LWW) semantics in the replication handler using operation IDs and timestamps. (`src/replication.rs`)

**Feature and API enhancements:**

* Adds support for additional replicated operations: `INCR`, `DECR`, `APPEND`, and `PREPEND`, each with dedicated publish methods. (`src/replication.rs`)
* Introduces a broadcast channel to decouple MQTT event polling from application of changes, modeling a classic ingress queue for replicated systems. (`src/replication.rs`) [[1]](diffhunk://#diff-a2e88f1e108c7f80dc6918e1b0aa875cdede712521e4adb4e578f4608e19aa99R66-R71) [[2]](diffhunk://#diff-a2e88f1e108c7f80dc6918e1b0aa875cdede712521e4adb4e578f4608e19aa99L118-R124)

**Integration and dependency updates:**

* Integrates the new replication system into the server startup flow, enabling background replication and event application when configured. (`src/server.rs`) [[1]](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9R281-R288) [[2]](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9R306-R308) [[3]](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9R353-R367)
* Adds new dependencies for codecs and event handling, including `serde_cbor`, `bincode`, `uuid`, `base64`, `once_cell`, and `rand`. (`Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R12-R13) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R22-R29)

These changes make the replication layer more robust, extensible, and production-ready, while also improving testability and future feature support.